### PR TITLE
add rocks ci for `pull_request` and `push` events

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,0 +1,13 @@
+name: On Pull Request
+
+on:
+  pull_request:
+
+jobs:
+
+  on-pull-request:
+    name: Get ROCKs modified and build-scan-test them
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
+    permissions:
+      pull-requests: read
+    secrets: inherit

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,0 +1,16 @@
+name: On Push
+
+on:
+  push:
+    branches:
+    - main
+    - track/**
+
+jobs:
+
+  on-push:
+    name: Get ROCKs modified and build-scan-test-publish them
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
+    permissions:
+      pull-requests: read
+    secrets: inherit


### PR DESCRIPTION
Implements the reusable workflows for rocks defined [here](https://github.com/canonical/charmed-kubeflow-workflows/tree/main/templates).  

Related to #7