### PR TITLE
chore: bump 2.36 -> 2.39

### DIFF
--- a/dex/rockcraft.yaml
+++ b/dex/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Dockerfile: https://github.com/dexidp/dex/blob/v2.36.0/Dockerfile
+# Dockerfile: https://github.com/dexidp/dex/blob/v2.39.1/Dockerfile
 name: dex
 summary: An image for dex
 description: An image for dex 
-version: "2.36.0"
+version: "2.39.1"
 base: ubuntu@22.04
 license: Apache-2.0
 platforms:
@@ -25,9 +25,9 @@ parts:
   builder:
     plugin: go
     source: https://github.com/dexidp/dex.git
-    source-tag: v2.36.0
+    source-tag: v2.39.1
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - GO111MODULE: "on"
       - GOARCH: "amd64"
@@ -76,7 +76,7 @@ parts:
   stager:
     plugin: nil
     source: https://github.com/dexidp/dex.git
-    source-tag: v2.36.0
+    source-tag: v2.39.1
     override-build: |-
       # Grant ownership to user 584792, which corresponds to the
       # _daemon_ user that will be executing in this rock
@@ -92,7 +92,7 @@ parts:
   gomplate:
     plugin: nil
     build-environment:
-      - GOMPLATE_VERSION: v3.11.4
+      - GOMPLATE_VERSION: v3.11.7
       - TARGETARCH: "amd64"
       - TARGETOS: "linux"
       - TARGETVARIANT: ""


### PR DESCRIPTION
Bump the rock workload version to 2.39.1.

I have based all changes on [this diff](https://github.com/dexidp/dex/compare/v2.36.0...v2.39.1#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) (look for Dockerfile) and the [Dockefile](https://github.com/dexidp/dex/blob/v2.39.1/Dockerfile) itself. Please note I did not include any of the cross-compilation bits (gcc, xx, lld, etc.) as this image is only built for x86.

Fixes #11

#### Testing the rock
1. Build the rock `rockcraft pack -v`
2. Copy the rock to a docker local registry `sudo skopeo --insecure-policy copy oci-archive:<dex-rock-name>.rock docker-daemon:dex:0.1`
3. Run a container with the image, verify the workload runs correctly. You can exec into the container and run:

```
_daemon_@6dd622009ec4:~$ /usr/local/bin/docker-entrypoint dex serve "/etc/dex/config.docker.yaml" 
time="2024-06-04T11:30:14Z" level=info msg="Dex Version: v2.39.1, Go Version: go1.21.10, Go OS/ARCH: linux amd64"
time="2024-06-04T11:30:14Z" level=info msg="config using log level: info"
time="2024-06-04T11:30:14Z" level=info msg="config issuer: http://127.0.0.1:5556/dex"
time="2024-06-04T11:30:14Z" level=info msg="config storage: sqlite3"
time="2024-06-04T11:30:14Z" level=info msg="config connector: local passwords enabled"
time="2024-06-04T11:30:14Z" level=info msg="config response types accepted: [code]"
time="2024-06-04T11:30:14Z" level=info msg="config signing keys expire after: 6h0m0s"
time="2024-06-04T11:30:14Z" level=info msg="config id tokens valid for: 24h0m0s"
time="2024-06-04T11:30:14Z" level=info msg="config auth requests valid for: 24h0m0s"
time="2024-06-04T11:30:14Z" level=info msg="config device requests valid for: 5m0s"
time="2024-06-04T11:30:14Z" level=info msg="config refresh tokens rotation enabled: true"
time="2024-06-04T11:30:14Z" level=info msg="keys expired, rotating"
time="2024-06-04T11:30:14Z" level=info msg="keys rotated, next rotation: 2024-06-04 17:30:14.14797701 +0000 UTC"
time="2024-06-04T11:30:14Z" level=info msg="listening (http) on 0.0.0.0:5556"
```

#### Testing with a charm
1. Deploy `dex-auth` with the rock as container image (make sure the image is in the k8s local registry or in a public one so the charm can pull it)
2. Wait for it to become active and idle