### PR TITLE
cut new branch for CKF 1.8

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,5 +14,5 @@ jobs:
     with:
       rockcraft-channel: latest/stable
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,5 +14,5 @@ jobs:
     with:
       rockcraft-channel: latest/stable
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.1/stable
+      juju-channel: 3.5/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -17,5 +17,5 @@ jobs:
     with:
       rockcraft-channel: latest/stable
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -17,5 +17,5 @@ jobs:
     with:
       rockcraft-channel: latest/stable
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.1/stable
+      juju-channel: 3.5/stable
       python-version: "3.8"

--- a/dex/rockcraft.yaml
+++ b/dex/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Dockerfile: https://github.com/dexidp/dex/blob/v2.36.0/Dockerfile
+# Dockerfile: https://github.com/dexidp/dex/blob/v2.39.1/Dockerfile
 name: dex
 summary: An image for dex
 description: An image for dex 
-version: "2.36.0"
+version: "2.39.1"
 base: ubuntu@22.04
 license: Apache-2.0
 platforms:
@@ -25,9 +25,9 @@ parts:
   builder:
     plugin: go
     source: https://github.com/dexidp/dex.git
-    source-tag: v2.36.0
+    source-tag: v2.39.1
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - GO111MODULE: "on"
       - GOARCH: "amd64"
@@ -76,7 +76,7 @@ parts:
   stager:
     plugin: nil
     source: https://github.com/dexidp/dex.git
-    source-tag: v2.36.0
+    source-tag: v2.39.1
     override-build: |-
       # Grant ownership to user 584792, which corresponds to the
       # _daemon_ user that will be executing in this rock
@@ -92,7 +92,7 @@ parts:
   gomplate:
     plugin: nil
     build-environment:
-      - GOMPLATE_VERSION: v3.11.4
+      - GOMPLATE_VERSION: v3.11.7
       - TARGETARCH: "amd64"
       - TARGETOS: "linux"
       - TARGETVARIANT: ""


### PR DESCRIPTION
This PR is part of closing [this issue](https://github.com/canonical/bundle-kubeflow/issues/924).

It updates `track/3.3` with the newest commits for CKF 1.8.