### PR TITLE
docs: add SECURITY.md to the repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security policy
+
+## Supported Versions
+
+The Charmed Kubeflow project releases with a cadence of ~6 months, supports the latest two minor versions of Kubeflow, and keeps up to date with the upstream project. Whenever a new version of Kubeflow is released, a new version of Charmed Kubeflow is also released, and the oldest version is dropped from support. Please also to [Supported versions](https://charmed-kubeflow.io/docs/supported-versions) for details on the actual versions.
+Since this repository contains rocks used by the Charmed Kubeflow project, the same policy is expected for the rocks and oci-images generated from them (i.e. 1.9-xxxxx).
+
+## Reporting a Vulnerability
+
+To report a security issue, file a [Private Security Report](https://github.com/canonical/bundle-kubeflow/security/advisories/new) with a description of the issue, the steps you took that led to the issue, affected versions, and, if known, mitigations for the issue.
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
This commit adds the SECURITY.md file to expose the security policy of the rockcraft project, as well as inform users how they can report security/vulnerability issues.

Fixes #17